### PR TITLE
Stefvtls bugfix profile stored translations

### DIFF
--- a/src/components/Login/LoginForm.jsx
+++ b/src/components/Login/LoginForm.jsx
@@ -38,9 +38,9 @@ export const LoginForm = () => {
 
     // EVENT HANDLERS
     // function defined to handle our custom event when submitting data
-    const onSubmit = async (inputtedName) => {        
+    const onSubmit = async (loginForm) => {        
         setLoading(true);                                    
-        const [errorFromAPI, userResponse] = await getUserOrCreateNewUser(inputtedName.name)        // async call to api to find or create user with the given string
+        const [errorFromAPI, userResponse] = await getUserOrCreateNewUser(loginForm.name)        // async call to api to find or create user with the given string
         if (errorFromAPI) {
             setApiError(errorFromAPI);                                                      
         } 

--- a/src/components/Profile/ProfileContainer.jsx
+++ b/src/components/Profile/ProfileContainer.jsx
@@ -1,20 +1,52 @@
-
+import { useUserContext } from "../../context/UserContext"
+import { clearTranslations } from "../../api/translationsAPI"
+import { useNavigate } from "react-router-dom";
 
 const ProfileContainer = (props) => {
-    //STEFVTLS props.user.translations.slice(0,10).reverse().map().... creating a copy of array from api and reversing it to display only latest 10 items
+    const { currentUser, setCurrentUser } = useUserContext();
+    const navigate = useNavigate();
+
+    //STEFVTLS props.user.translations.slice(0).reverse()..
+    //... creating a copy of array from api and reversing it to have last items first, 
+    // we dont want to reverse the original array! 
+    // then .slice(0,10).map() to get only last 10 items and not all of them
     const listOfTranslations = props.user.translations.slice(0).reverse().slice(0,10).map( (t,index)=>
         <div className="alert alert-warning" role="alert" key={index}>
             {t}
         </div>
     )
 
+    const handleClickClearingAllTranslations = async () => {
+        const [error, result] = await clearTranslations(currentUser);
+        setCurrentUser(result)
+
+        console.log(error)
+        console.log(result)
+
+
+    }
+
+    const handleClickNavigateToTranslations = () => {
+        navigate("/translations")
+    }
+
     return (
     <div className="css-container">
         <div className={'container'}>
             <h1>Welcome back, {props.user.username}</h1>
-            <h5> Here is the list of your 10 last translations in order from the most recent to the latest </h5>
+            <br></br>
+            <br></br>
+            <br></br>
+            { listOfTranslations.length !== 0 && <h5> Here is the list of your 10 last translations in order from the most recent to the latest </h5>}
+            <br></br>
+            <br></br>
+            <br></br>
+            { listOfTranslations.length === 0 && <h5> nothing to show here, we will display history of your last 10 translations as soon as you will use our translations app </h5>}
             <br></br>
             <ul> {listOfTranslations} </ul>
+            <br></br>
+            { listOfTranslations.length !== 0 && <button onClick={handleClickClearingAllTranslations}> Clear all translations </button>}
+            <button onClick={handleClickNavigateToTranslations}> Translate something new! </button>
         </div>
     </div>
     )

--- a/src/components/Profile/ProfileContainer.jsx
+++ b/src/components/Profile/ProfileContainer.jsx
@@ -1,7 +1,8 @@
 
 
 const ProfileContainer = (props) => {
-    const listOfTranslations = props.user.translations.map( (t,index)=>
+    //STEFVTLS props.user.translations.slice(0,10).reverse().map().... creating a copy of array from api and reversing it to display only latest 10 items
+    const listOfTranslations = props.user.translations.slice(0).reverse().slice(0,10).map( (t,index)=>
         <div className="alert alert-warning" role="alert" key={index}>
             {t}
         </div>
@@ -10,7 +11,9 @@ const ProfileContainer = (props) => {
     return (
     <div className="css-container">
         <div className={'container'}>
-            <h1>Welcome, {props.user.username}</h1>
+            <h1>Welcome back, {props.user.username}</h1>
+            <h5> Here is the list of your 10 last translations in order from the most recent to the latest </h5>
+            <br></br>
             <ul> {listOfTranslations} </ul>
         </div>
     </div>

--- a/src/components/Translate/TranslateContainer.css
+++ b/src/components/Translate/TranslateContainer.css
@@ -1,4 +1,4 @@
-.result-container{
+/* .result-container{
     position: relative;
     top: 4rem;
 }
@@ -6,4 +6,4 @@
 .btn-translation{
     position: relative;
     top: 1rem;
-}
+} */

--- a/src/components/Translate/TranslateContainer.jsx
+++ b/src/components/Translate/TranslateContainer.jsx
@@ -16,7 +16,7 @@ const TranslateContainer = ({onTranslateRequest}) => {
                         <input type="text" className="form-control" id="exampleInputEmail1" {... register("translationRequest")} aria-describedby="emailHelp"/>
                     </div>
                     <div className={'col-md-2'}>
-                        <button className={'btn btn-primary'}> > </button>
+                        <button className={'btn btn-primary'}> </button>
                     </div>
                 </div>
 

--- a/src/views/TranslationPage.jsx
+++ b/src/views/TranslationPage.jsx
@@ -8,20 +8,28 @@ import {updateTranslations} from "../api/translationsAPI"
 import "./view.css"
 
 const TranslationPage = () => {
-    const { currentUser } = useUserContext()   
+    const { currentUser, setCurrentUser } = useUserContext()   
 
-    const [requestedTransltation, setrequestedTransltation] = useState([])
+    const [requestedTranslation, setRequestedTranslation] = useState([])
 
     const handleTranslateClicked =async({ translationRequest }) => {
-        setrequestedTransltation(translationRequest.split(""))
 
-        const [error,result] = await updateTranslations(currentUser, translationRequest)
+        const newTranslation = translationRequest.split("")
+        // STEFVTLS: if no input do not bother for translations, just ignore it,
+        // we will not update the API and current state, so empty translation will not show up on the profile page
+        if (newTranslation.length !== 0 ) {
+            setRequestedTranslation(newTranslation)
+            const [error,result] = await updateTranslations(currentUser, translationRequest)
 
-        console.log('Error', error)
-        console.log('Result', result)
+            // STEFVTLS: you need to change the state of the user except of changing the API, otherwise API updates, but the components in the app does not know about it
+            setCurrentUser(result)
+
+            console.log('Error', error)
+            console.log('Result', result)
+        }
     }
 
-    let hands = requestedTransltation.map(letter =>
+    let hands = requestedTranslation.map(letter =>
         <div className={'col-md-3'}>
             <div className="card">
                 <img key={letter} src={process.env.PUBLIC_URL +`/resources/signs/${letter.toLowerCase()}.png`} className="card-img-top" alt="..."/>


### PR DESCRIPTION
fixed bugs:
- profile page display all the translations insted of 10 latest
- empty inputs are stored as translations and displayed on the profile page
- new translations does not immediately show up on the profile and only after login in and out
added features:
- button on profile page to clear translations
- button to go back to translations page from the profile page
